### PR TITLE
Potential fix for code scanning alert no. 2: CSRF protection weakened or disabled

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,3 @@
 class ApplicationController < ActionController::Base
-  protect_from_forgery
+  protect_from_forgery with: :exception
 end


### PR DESCRIPTION
Potential fix for [https://github.com/juswaldy/matchi/security/code-scanning/2](https://github.com/juswaldy/matchi/security/code-scanning/2)

In general, the fix is to ensure that CSRF protection uses a strict strategy that raises an exception on invalid or missing tokens, rather than silently nulling the session. In Rails, this is done by calling `protect_from_forgery with: :exception` (or by not overriding the framework default in recent Rails versions). This change keeps existing functionality while strengthening the security behavior on CSRF failures.

Concretely for this code, change the `protect_from_forgery` call in `app/controllers/application_controller.rb` to include the `with: :exception` option. This is a one-line modification: on line 2, replace `protect_from_forgery` with `protect_from_forgery with: :exception`. No additional methods or imports are required, as `protect_from_forgery` and the `:exception` strategy are provided by `ActionController::Base`. All controllers inheriting from `ApplicationController` will then raise an exception when a request has an invalid or missing CSRF token, aligning the app with Rails’ recommended CSRF protection behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
