### PR TITLE
Potential fix for code scanning alert no. 3: Stored cross-site scripting

### DIFF
--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -31,7 +31,7 @@
     <td><%= player.score %></td>
     <td><%= player.assist %></td>
     <td><%= player.strength %></td>
-    <td><%= link_to 'Show', player %></td>
+    <td><%= link_to 'Show', player_path(player.id) %></td>
     <td><%= link_to 'Edit', edit_player_path(player) %></td>
   </tr>
 <% end %>


### PR DESCRIPTION
Potential fix for [https://github.com/juswaldy/matchi/security/code-scanning/3](https://github.com/juswaldy/matchi/security/code-scanning/3)

To fix this issue, we should ensure that the `link_to` helper does not use any user-controlled or unsanitized fields in the URL. The safest approach is to explicitly use the player's `id` (which should be an integer and not user-controlled) when generating the link, rather than passing the entire `player` object. This avoids any risk from a potentially overridden `to_param` method or routes that use user-controlled fields. 

Specifically, in `app/views/teams/show.html.erb`, on line 34, replace `<%= link_to 'Show', player %>` with `<%= link_to 'Show', player_path(player.id) %>`. This ensures that only the integer `id` is used in the URL, preventing any stored XSS via route parameters.

No additional imports or methods are needed, as `player_path` is a standard Rails route helper.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
